### PR TITLE
Upgrade websocket-extensions to version 0.1.5 or later.

### DIFF
--- a/rails/session-manager/Gemfile
+++ b/rails/session-manager/Gemfile
@@ -48,3 +48,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "websocket-extensions", ">= 0.1.5"


### PR DESCRIPTION
https://github.com/willy23martin/ruby_and_rails_learning/network/alert/rails/session-manager/Gemfile.lock/websocket-extensions/closed